### PR TITLE
[APPHUD-890] Add setScreenPresentationStyle for iOS Rules screens

### DIFF
--- a/android/src/main/java/com/reactnativeapphudsdk/ApphudListenerHandler.kt
+++ b/android/src/main/java/com/reactnativeapphudsdk/ApphudListenerHandler.kt
@@ -53,6 +53,11 @@ class ApphudListenerHandler(private val reactContext: ReactApplicationContext) :
     promise.resolve(ids)
   }
 
+  /** iOS-only: Rules screens presentation style. Safe no-op on Android. */
+  override fun setScreenPresentationStyle(style: String, promise: Promise) {
+    promise.resolve(null)
+  }
+
   internal fun emitRuleEvent(event: ApphudRuleEvent, body: WritableMap) {
     runOnUiThread {
       when (event) {

--- a/ios/ApphudSdkEvents.swift
+++ b/ios/ApphudSdkEvents.swift
@@ -23,6 +23,11 @@ public final class ApphudSdkEventsImpl: NSObject {
 
   fileprivate var productIdentifiers: [String] = []
 
+  /// Modal presentation style for Rules screens, set via
+  /// `setScreenPresentationStyle`. `nil` means "never set": the delegate
+  /// selector stays hidden and the SDK keeps its default behavior.
+  fileprivate var screenPresentationStyle: UIModalPresentationStyle?
+
   private lazy var delegateProxy = ApphudEventsDelegateProxy(owner: self)
 
   /// Keeps the events module that installed the deep link handler, so it can be
@@ -87,6 +92,28 @@ public final class ApphudSdkEventsImpl: NSObject {
     self.productIdentifiers = ids as? [String] ?? []
     resolve(self.productIdentifiers)
   }
+
+  @objc(setScreenPresentationStyle:withResolve:withReject:)
+  public func setScreenPresentationStyle(
+    style: NSString,
+    resolve: @escaping RCTPromiseResolveBlock,
+    reject: RCTPromiseRejectBlock
+  ) -> Void {
+    // The UI delegate reads the style on the main thread; keep the write on
+    // the same thread so a set → show sequence can't race.
+    DispatchQueue.main.async {
+      // Only two supported values; anything else is ignored, state unchanged.
+      switch style as String {
+      case "fullScreen":
+        self.screenPresentationStyle = .fullScreen
+      case "pageSheet":
+        self.screenPresentationStyle = .pageSheet
+      default:
+        NSLog("[Apphud] setScreenPresentationStyle: unsupported style '\(style)', ignoring")
+      }
+      resolve(nil)
+    }
+  }
 }
 
 /// Receives every Apphud delegate callback on behalf of `ApphudSdkEventsImpl`.
@@ -99,6 +126,17 @@ private final class ApphudEventsDelegateProxy: NSObject {
 
   var emitter: (any ApphudSdkEventsEmitting)? {
     owner?.emitter
+  }
+
+  /// While no presentation style is set, hide the optional delegate selector
+  /// so the native SDK behaves exactly as if the method was never implemented
+  /// (its `apphudScreenPresentationStyle?(...)` optional call resolves to
+  /// `nil` and the screen keeps the system default presentation).
+  override func responds(to aSelector: Selector!) -> Bool {
+    if aSelector == #selector(ApphudUIDelegate.apphudScreenPresentationStyle(controller:)) {
+      return owner?.screenPresentationStyle != nil
+    }
+    return super.responds(to: aSelector)
   }
 }
 
@@ -148,6 +186,12 @@ extension ApphudEventsDelegateProxy: ApphudDelegate {
 }
 
 extension ApphudEventsDelegateProxy: ApphudUIDelegate {
+
+  func apphudScreenPresentationStyle(controller: UIViewController) -> UIModalPresentationStyle {
+    // `responds(to:)` guarantees this is only reached when a style is set;
+    // the fallback keeps the compiler satisfied.
+    return owner?.screenPresentationStyle ?? .pageSheet
+  }
 
   private func sanitize(_ map: [String: Any?]) -> [String: Any] {
     var result: [String: Any] = [:]

--- a/ios/ApphudSdkEventsModule.mm
+++ b/ios/ApphudSdkEventsModule.mm
@@ -68,6 +68,13 @@ RCT_EXPORT_MODULE(ApphudSdkEvents)
   [_impl setApphudProductIdentifiers:ids withResolve:resolve withReject:reject];
 }
 
+- (void)setScreenPresentationStyle:(NSString *)style
+                           resolve:(RCTPromiseResolveBlock)resolve
+                            reject:(RCTPromiseRejectBlock)reject
+{
+  [_impl setScreenPresentationStyle:style withResolve:resolve withReject:reject];
+}
+
 #pragma mark - ApphudSdkEventsEmitting
 
 - (void)emitPlacementsDidFullyLoad:(NSArray *)value

--- a/src/module/ApphudSdk.ts
+++ b/src/module/ApphudSdk.ts
@@ -1,5 +1,6 @@
 import { Platform } from 'react-native';
 import NativeApphudSdk from '../specs/NativeApphudSdk';
+import NativeApphudSdkEvents from '../specs/NativeApphudSdkEvents';
 import {
   PaywallScreenPresenter,
   type Options as PaywallScreenPresenterOptions,
@@ -23,6 +24,7 @@ import type {
   PaywallLogsInfo,
   PlacementsOptions,
   CommitmentPlanProductOptions,
+  ApphudScreenPresentationStyle,
 } from './types';
 
 interface IApphudSdk {
@@ -362,6 +364,17 @@ interface IApphudSdk {
   checkRules(): Promise<void>;
 
   /**
+   * Available on iOS only. Safe no-op on Android.
+   *
+   * Sets the modal presentation style for Apphud Rules screens (including
+   * Figma rule paywalls). Applies to all Rules screens presented after this
+   * call. If never called, screens keep the SDK's default presentation.
+   */
+  setScreenPresentationStyle(
+    style: ApphudScreenPresentationStyle
+  ): Promise<void>;
+
+  /**
    * Available on iOS and Android.
    *
    * Returns the Apphud rule whose screen is currently pending or displayed, if any.
@@ -526,6 +539,8 @@ export const ApphudSdk: IApphudSdk & ApphudSdkPresenterProvider = {
   logout: () => NativeApphudSdk.logout(),
   enableDebugLogs: () => NativeApphudSdk.enableDebugLogs(),
   checkRules: () => NativeApphudSdk.checkRules(),
+  setScreenPresentationStyle: (style: ApphudScreenPresentationStyle) =>
+    NativeApphudSdkEvents.setScreenPresentationStyle(style),
   pendingRule: () =>
     NativeApphudSdk.pendingRule() as Promise<ApphudRule | null>,
   showPendingRuleScreen: () => NativeApphudSdk.showPendingRuleScreen(),

--- a/src/module/types.ts
+++ b/src/module/types.ts
@@ -613,6 +613,12 @@ export enum ApphudAttributionProvider {
   custom = 'custom',
 }
 
+/** iOS modal presentation styles for Apphud Rules screens. */
+export enum ApphudScreenPresentationStyle {
+  fullScreen = 'fullScreen',
+  pageSheet = 'pageSheet',
+}
+
 export interface ApphudAttributionData {
   /** Raw attribution data received from MMPs, such as AppsFlyer or Branch. */
   rawData: Record<string, any>;

--- a/src/specs/NativeApphudSdkEvents.ts
+++ b/src/specs/NativeApphudSdkEvents.ts
@@ -45,6 +45,8 @@ export interface Spec extends TurboModule {
   readonly onApphudDeeplinkAttribution: CodegenTypes.EventEmitter<CodegenTypes.UnsafeObject>;
 
   setApphudProductIdentifiers(ids: string[]): Promise<string[]>;
+
+  setScreenPresentationStyle(style: string): Promise<void>;
 }
 
 export default TurboModuleRegistry.getEnforcing<Spec>('ApphudSdkEvents');


### PR DESCRIPTION
Adds `ApphudSdk.setScreenPresentationStyle(ApphudScreenPresentationStyle.fullScreen | pageSheet)` to control how Rules screens (including Figma rule paywalls) are presented on iOS.

**Why a separate method:** the native `ApphudUIDelegate.apphudScreenPresentationStyle` returns synchronously and cannot be bridged to async JS. The style is stored in the events module (same pattern as `setApphudProductIdentifiers`) and returned by the existing UI delegate proxy.

**Behavior details:**
- While the method was never called, the proxy hides the optional selector via `responds(to:)` — SDK default behavior preserved byte-for-byte.
- The write happens on the main thread (same thread the delegate reads from), so a set → show sequence can't race; the returned `Promise` resolves after the write.
- Android: safe no-op (codegen-required stub resolves immediately).
- New Turbo Module spec method `setScreenPresentationStyle(style: string): Promise<void>` on `NativeApphudSdkEvents`; TS enum `ApphudScreenPresentationStyle` in `types.ts`.

Verified: `tsc` + `eslint` clean, codegen regenerated, example built and smoke-tested on iOS simulator (both styles visually confirmed via a temporary local trigger, not committed) and Android emulator (no-op path). Example app intentionally untouched.
