### PR TITLE
[APPHUD-935] Fix iOS build on React Native 0.87

### DIFF
--- a/ios/ApphudPaywallScreenView.mm
+++ b/ios/ApphudPaywallScreenView.mm
@@ -8,6 +8,10 @@
 
 #import "ApphudRNBridge.h"
 
+// RN 0.87: React typedefs must be imported before the generated -Swift.h.
+#import <React/RCTBridgeModule.h>
+#import <React/RCTComponent.h>
+
 #if __has_include(<react_native_apphud_sdk/react_native_apphud_sdk-Swift.h>)
 #import <react_native_apphud_sdk/react_native_apphud_sdk-Swift.h>
 #else

--- a/ios/ApphudSdkEventsModule.mm
+++ b/ios/ApphudSdkEventsModule.mm
@@ -2,6 +2,10 @@
 
 #import "ApphudRNBridge.h"
 
+// RN 0.87: React typedefs must be imported before the generated -Swift.h.
+#import <React/RCTBridgeModule.h>
+#import <React/RCTComponent.h>
+
 #if __has_include(<react_native_apphud_sdk/react_native_apphud_sdk-Swift.h>)
 #import <react_native_apphud_sdk/react_native_apphud_sdk-Swift.h>
 #else

--- a/ios/ApphudSdkModule.mm
+++ b/ios/ApphudSdkModule.mm
@@ -1,5 +1,9 @@
 #import <ApphudSdkSpec/ApphudSdkSpec.h>
 
+// RN 0.87: React typedefs must be imported before the generated -Swift.h.
+#import <React/RCTBridgeModule.h>
+#import <React/RCTComponent.h>
+
 #if __has_include(<react_native_apphud_sdk/react_native_apphud_sdk-Swift.h>)
 #import <react_native_apphud_sdk/react_native_apphud_sdk-Swift.h>
 #else

--- a/ios/PaywallscreenPresenterModule.mm
+++ b/ios/PaywallscreenPresenterModule.mm
@@ -2,6 +2,10 @@
 
 #import "ApphudRNBridge.h"
 
+// RN 0.87: React typedefs must be imported before the generated -Swift.h.
+#import <React/RCTBridgeModule.h>
+#import <React/RCTComponent.h>
+
 #if __has_include(<react_native_apphud_sdk/react_native_apphud_sdk-Swift.h>)
 #import <react_native_apphud_sdk/react_native_apphud_sdk-Swift.h>
 #else


### PR DESCRIPTION
RN 0.87 (prebuilt React core) changed the header layout: the React typedefs used by
the generated `react_native_apphud_sdk-Swift.h` are no longer visible transitively,
so all four `.mm` files fail to compile on RN 0.87.

Fix: import `<React/RCTBridgeModule.h>` and `<React/RCTComponent.h>` before the
generated Swift header in those four files. +16 lines, nothing else changed.
Backward compatible: the umbrella header has always imported the same headers,
`#import` is idempotent — only the visibility order inside each file changes.

Verified: RN 0.87 fresh app — fails unpatched, builds with the patch, launches with
a live TurboModule call; RN 0.86.2 example app builds green.

Merge after #95 (no conflict: it edits `ApphudSdkEventsModule.mm` mid-file, this PR
only touches header blocks; will rebase after it lands).
